### PR TITLE
Handle CRLF whitespace in CSV parser

### DIFF
--- a/app/src/main/java/com/example/kwh/ui/history/HistoryViewModel.kt
+++ b/app/src/main/java/com/example/kwh/ui/history/HistoryViewModel.kt
@@ -1,0 +1,57 @@
+package com.example.kwh.ui.history
+
+import androidx.lifecycle.ViewModel
+
+/**
+ * ViewModel backing the history import/export flows.
+ *
+ * Only a minimal CSV parser is implemented for testing purposes. The parser expects the CSV to
+ * contain a header row followed by one row per reading with the following columns:
+ * 1. meter id (Long)
+ * 2. recorded at timestamp (epoch millis as Long)
+ * 3. reading value (Double)
+ * 4. optional notes column
+ */
+class HistoryViewModel : ViewModel() {
+
+    data class CsvRow(
+        val meterId: Long,
+        val recordedAtEpochMillis: Long,
+        val value: Double,
+        val notes: String?
+    )
+
+    class CsvParser {
+        fun parse(csv: String): List<CsvRow> {
+            if (csv.isBlank()) return emptyList()
+
+            val rows = mutableListOf<CsvRow>()
+            val iterator = csv.splitToSequence('\n').iterator()
+
+            if (!iterator.hasNext()) {
+                return emptyList()
+            }
+
+            // Skip the header row
+            iterator.next()
+
+            while (iterator.hasNext()) {
+                val rawLine = iterator.next().trimEnd('\r')
+                if (rawLine.isBlank()) continue
+
+                val columns = rawLine.split(',')
+                require(columns.size >= 3) { "CSV row must contain at least 3 columns" }
+
+                val meterId = columns[0].trim().toLong()
+                val recordedAt = columns[1].trim().toLong()
+                val value = columns[2].trim().toDouble()
+                val notes = columns.getOrNull(3)?.trim()?.takeIf { it.isNotEmpty() }
+
+                rows.add(CsvRow(meterId, recordedAt, value, notes))
+            }
+
+            return rows
+        }
+    }
+}
+

--- a/app/src/test/java/com/example/kwh/ui/history/HistoryViewModelTest.kt
+++ b/app/src/test/java/com/example/kwh/ui/history/HistoryViewModelTest.kt
@@ -1,0 +1,37 @@
+package com.example.kwh.ui.history
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class HistoryViewModelTest {
+
+    private val parser = HistoryViewModel.CsvParser()
+
+    @Test
+    fun `parse handles CRLF endings`() {
+        val csv = buildString {
+            appendLine("meter_id,recorded_at,value,notes")
+            append("1,1700000000000,123.45, note with spaces \r\n")
+        }
+
+        val rows = parser.parse(csv)
+
+        assertEquals(1, rows.size)
+        val row = rows.first()
+        assertEquals(1L, row.meterId)
+        assertEquals(1700000000000L, row.recordedAtEpochMillis)
+        assertEquals(123.45, row.value, 0.0)
+        assertEquals("note with spaces", row.notes)
+    }
+
+    @Test
+    fun `parse handles missing notes`() {
+        val csv = "meter_id,recorded_at,value\r\n2,1700000001000,42.0\r\n"
+
+        val rows = parser.parse(csv)
+
+        assertEquals(1, rows.size)
+        assertNull(rows.first().notes)
+    }
+}


### PR DESCRIPTION
## Summary
- add a HistoryViewModel CSV parser that trims numeric and notes columns before conversion
- cover CRLF terminated rows and missing notes with unit tests to keep imports resilient

## Testing
- `/tmp/gradle-8.14.3/bin/gradle test` *(fails: Android SDK components not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d6f1e025748323807dd27562a3c327