### PR TITLE
Add billing anchor data and cycle calculator

### DIFF
--- a/app/src/main/java/com/example/kwh/billing/BillingCycleCalculator.kt
+++ b/app/src/main/java/com/example/kwh/billing/BillingCycleCalculator.kt
@@ -1,0 +1,55 @@
+package com.example.kwh.billing
+
+import java.time.Clock
+import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneId
+
+/**
+ * Represents the time window for a billing cycle. The window is half-open, i.e. it includes
+ * [start] and excludes [end].
+ */
+data class CycleWindow(val start: Instant, val end: Instant) {
+    init {
+        require(end.isAfter(start)) { "Cycle end must be after start" }
+    }
+}
+
+/**
+ * Calculates billing cycle boundaries based on an anchor day supplied by the utility.
+ */
+interface BillingCycleCalculator {
+    fun currentWindow(anchorDay: Int, clock: Clock = Clock.systemDefaultZone()): CycleWindow
+}
+
+/**
+ * Default implementation of [BillingCycleCalculator]. It interprets the billing anchor day as the
+ * utility's reading date for each month. When the month does not contain the anchor day (e.g., the
+ * 31st in February) the final day of the month is used instead.
+ */
+class DefaultBillingCycleCalculator : BillingCycleCalculator {
+
+    override fun currentWindow(anchorDay: Int, clock: Clock): CycleWindow {
+        require(anchorDay in 1..31) { "Anchor day must be within 1..31" }
+
+        val zone: ZoneId = clock.zone
+        val today = LocalDate.now(clock)
+        val cycleStartDate = resolveCycleStart(today, anchorDay)
+        val cycleEndDate = cycleStartDate.plusMonths(1)
+
+        return CycleWindow(
+            start = cycleStartDate.atStartOfDay(zone).toInstant(),
+            end = cycleEndDate.atStartOfDay(zone).toInstant()
+        )
+    }
+
+    private fun resolveCycleStart(today: LocalDate, anchorDay: Int): LocalDate {
+        val anchorThisMonth = today.withDayOfMonth(anchorDay.coerceAtMost(today.lengthOfMonth()))
+        return if (!anchorThisMonth.isAfter(today)) {
+            anchorThisMonth
+        } else {
+            val previousMonth = today.minusMonths(1)
+            previousMonth.withDayOfMonth(anchorDay.coerceAtMost(previousMonth.lengthOfMonth()))
+        }
+    }
+}

--- a/app/src/main/java/com/example/kwh/billing/BillingCycleCalculator.kt
+++ b/app/src/main/java/com/example/kwh/billing/BillingCycleCalculator.kt
@@ -45,7 +45,7 @@ class DefaultBillingCycleCalculator : BillingCycleCalculator {
 
     private fun resolveCycleStart(today: LocalDate, anchorDay: Int): LocalDate {
         val anchorThisMonth = today.withDayOfMonth(anchorDay.coerceAtMost(today.lengthOfMonth()))
-        return if (!anchorThisMonth.isAfter(today)) {
+        return if (anchorThisMonth <= today) {
             anchorThisMonth
         } else {
             val previousMonth = today.minusMonths(1)

--- a/app/src/main/java/com/example/kwh/data/MeterDatabase.kt
+++ b/app/src/main/java/com/example/kwh/data/MeterDatabase.kt
@@ -4,10 +4,12 @@ import android.content.Context
 import androidx.room.Database
 import androidx.room.Room
 import androidx.room.RoomDatabase
+import androidx.room.migration.Migration
+import androidx.sqlite.db.SupportSQLiteDatabase
 
 @Database(
     entities = [MeterEntity::class, MeterReadingEntity::class],
-    version = 1,
+    version = 2,
     exportSchema = false
 )
 abstract class MeterDatabase : RoomDatabase() {
@@ -23,7 +25,21 @@ abstract class MeterDatabase : RoomDatabase() {
                     context.applicationContext,
                     MeterDatabase::class.java,
                     "meter.db"
-                ).build().also { INSTANCE = it }
+                )
+                    .addMigrations(MIGRATION_1_2)
+                    .build()
+                    .also { INSTANCE = it }
+            }
+        }
+
+        val MIGRATION_1_2 = object : Migration(1, 2) {
+            override fun migrate(database: SupportSQLiteDatabase) {
+                database.execSQL(
+                    "ALTER TABLE meters ADD COLUMN billing_anchor_day INTEGER NOT NULL DEFAULT 1"
+                )
+                database.execSQL(
+                    "ALTER TABLE meters ADD COLUMN thresholds_csv TEXT NOT NULL DEFAULT '200,300'"
+                )
             }
         }
     }

--- a/app/src/main/java/com/example/kwh/data/MeterEntity.kt
+++ b/app/src/main/java/com/example/kwh/data/MeterEntity.kt
@@ -11,5 +11,7 @@ data class MeterEntity(
     @ColumnInfo(name = "reminder_enabled") val reminderEnabled: Boolean = false,
     @ColumnInfo(name = "reminder_frequency_days") val reminderFrequencyDays: Int = 30,
     @ColumnInfo(name = "reminder_hour") val reminderHour: Int = 9,
-    @ColumnInfo(name = "reminder_minute") val reminderMinute: Int = 0
+    @ColumnInfo(name = "reminder_minute") val reminderMinute: Int = 0,
+    @ColumnInfo(name = "billing_anchor_day", defaultValue = "1") val billingAnchorDay: Int = 1,
+    @ColumnInfo(name = "thresholds_csv", defaultValue = "'200,300'") val thresholdsCsv: String = "200,300"
 )

--- a/app/src/main/java/com/example/kwh/di/DatabaseModule.kt
+++ b/app/src/main/java/com/example/kwh/di/DatabaseModule.kt
@@ -22,7 +22,9 @@ object DatabaseModule {
             context,
             MeterDatabase::class.java,
             "meter.db"
-        ).build()
+        )
+            .addMigrations(MeterDatabase.MIGRATION_1_2)
+            .build()
     }
 
     @Provides

--- a/app/src/test/java/com/example/kwh/billing/DefaultBillingCycleCalculatorTest.kt
+++ b/app/src/test/java/com/example/kwh/billing/DefaultBillingCycleCalculatorTest.kt
@@ -1,0 +1,54 @@
+package com.example.kwh.billing
+
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneId
+import java.time.ZoneOffset
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+class DefaultBillingCycleCalculatorTest {
+
+    private val calculator = DefaultBillingCycleCalculator()
+    private val zone: ZoneId = ZoneOffset.UTC
+
+    @Test
+    fun `anchor within current month uses same month`() {
+        val clock = Clock.fixed(Instant.parse("2024-05-20T12:00:00Z"), zone)
+
+        val window = calculator.currentWindow(anchorDay = 15, clock = clock)
+
+        assertEquals("2024-05-15", window.start.atZone(zone).toLocalDate().toString())
+        assertEquals("2024-06-15", window.end.atZone(zone).toLocalDate().toString())
+    }
+
+    @Test
+    fun `anchor beyond month length falls back to previous month`() {
+        val clock = Clock.fixed(Instant.parse("2023-03-30T00:00:00Z"), zone)
+
+        val window = calculator.currentWindow(anchorDay = 31, clock = clock)
+
+        assertEquals("2023-02-28", window.start.atZone(zone).toLocalDate().toString())
+        assertEquals("2023-03-28", window.end.atZone(zone).toLocalDate().toString())
+    }
+
+    @Test
+    fun `leap year preserves february 29 for anchor 31`() {
+        val clock = Clock.fixed(Instant.parse("2024-02-20T00:00:00Z"), zone)
+
+        val window = calculator.currentWindow(anchorDay = 31, clock = clock)
+
+        assertEquals("2024-01-31", window.start.atZone(zone).toLocalDate().toString())
+        assertEquals("2024-02-29", window.end.atZone(zone).toLocalDate().toString())
+    }
+
+    @Test
+    fun `invalid anchor throws`() {
+        val clock = Clock.fixed(Instant.parse("2024-05-20T00:00:00Z"), zone)
+
+        assertFailsWith<IllegalArgumentException> {
+            calculator.currentWindow(anchorDay = 0, clock = clock)
+        }
+    }
+}

--- a/app/src/test/java/com/example/kwh/data/MeterDaoTest.kt
+++ b/app/src/test/java/com/example/kwh/data/MeterDaoTest.kt
@@ -23,6 +23,10 @@ class MeterDaoTest {
     @Test
     fun insertMeterAndReadings_emitsLatestReading() = runTest {
         val meterId = dao.insertMeter(MeterEntity(name = "Home"))
+        val inserted = dao.getMeterById(meterId)
+        assertNotNull(inserted)
+        assertEquals(1, inserted.billingAnchorDay)
+        assertEquals("200,300", inserted.thresholdsCsv)
         dao.insertReading(
             MeterReadingEntity(
                 meterId = meterId,


### PR DESCRIPTION
## Summary
- add billing anchor and thresholds columns to MeterEntity with migration support
- register the Room migration in the database builders
- introduce a billing cycle calculator with unit coverage for edge cases

## Testing
- `./gradlew test` *(fails: requires local Android SDK)*

------
https://chatgpt.com/codex/tasks/task_e_68e0bd62f3bc832384fb62e672ece554