### PR TITLE
Add Android CI workflow

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -1,0 +1,28 @@
+name: Android CI
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 17
+      - name: Gradle cache
+        uses: gradle/actions/setup-gradle@v3
+      - name: Unit tests
+        run: ./gradlew test
+      - name: Lint (non-blocking)
+        run: ./gradlew lintDebug || true
+      - name: Build debug APK
+        run: ./gradlew assembleDebug
+      - name: Upload APK
+        uses: actions/upload-artifact@v4
+        with:
+          name: app-debug-apk
+          path: app/build/outputs/apk/debug/*.apk

--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches: [ "main" ]
   pull_request:
+    branches: [ "main" ]
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to run Gradle tests and build debug APK
- upload debug APK artifact for easy download from CI

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68e0c7ddd2a483238eddccdf1880a80d