### PR TITLE
Add cycle stats projections and reminder messaging

### DIFF
--- a/app/src/main/java/com/example/kwh/billing/BillingCycleCalculator.kt
+++ b/app/src/main/java/com/example/kwh/billing/BillingCycleCalculator.kt
@@ -1,5 +1,6 @@
 package com.example.kwh.billing
 
+import com.example.kwh.data.MeterReadingEntity
 import java.time.Clock
 import java.time.Instant
 import java.time.LocalDate
@@ -21,6 +22,16 @@ data class CycleWindow(val start: Instant, val end: Instant) {
 interface BillingCycleCalculator {
     fun currentWindow(anchorDay: Int, clock: Clock = Clock.systemDefaultZone()): CycleWindow
 }
+
+data class CycleStats(
+    val window: CycleWindow,
+    val baseline: MeterReadingEntity?,
+    val latest: MeterReadingEntity?,
+    val usedUnits: Double,
+    val projectedUnits: Double?,
+    val nextThreshold: Int?,
+    val nextThresholdDate: LocalDate?
+)
 
 /**
  * Default implementation of [BillingCycleCalculator]. It interprets the billing anchor day as the

--- a/app/src/main/java/com/example/kwh/data/MeterDao.kt
+++ b/app/src/main/java/com/example/kwh/data/MeterDao.kt
@@ -24,6 +24,29 @@ interface MeterDao {
     @Query("SELECT * FROM meter_readings WHERE id = :readingId")
     suspend fun getReadingById(readingId: Long): MeterReadingEntity?
 
+    @Query(
+        "SELECT * FROM meter_readings WHERE meter_id = :meterId AND recorded_at < :start ORDER BY recorded_at DESC LIMIT 1"
+    )
+    suspend fun getLatestReadingBefore(meterId: Long, start: Long): MeterReadingEntity?
+
+    @Query(
+        "SELECT * FROM meter_readings WHERE meter_id = :meterId AND recorded_at >= :start AND recorded_at < :end ORDER BY recorded_at ASC LIMIT 1"
+    )
+    suspend fun getEarliestReadingInWindow(
+        meterId: Long,
+        start: Long,
+        end: Long
+    ): MeterReadingEntity?
+
+    @Query(
+        "SELECT * FROM meter_readings WHERE meter_id = :meterId AND recorded_at >= :start AND recorded_at < :end ORDER BY recorded_at DESC LIMIT 1"
+    )
+    suspend fun getLatestReadingInWindow(
+        meterId: Long,
+        start: Long,
+        end: Long
+    ): MeterReadingEntity?
+
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insertMeter(meter: MeterEntity): Long
 

--- a/app/src/main/java/com/example/kwh/di/BillingModule.kt
+++ b/app/src/main/java/com/example/kwh/di/BillingModule.kt
@@ -1,0 +1,25 @@
+package com.example.kwh.di
+
+import com.example.kwh.billing.BillingCycleCalculator
+import com.example.kwh.billing.DefaultBillingCycleCalculator
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import java.time.Clock
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object BillingModule {
+
+    @Provides
+    @Singleton
+    fun provideBillingCycleCalculator(): BillingCycleCalculator {
+        return DefaultBillingCycleCalculator()
+    }
+
+    @Provides
+    @Singleton
+    fun provideClock(): Clock = Clock.systemDefaultZone()
+}

--- a/app/src/main/java/com/example/kwh/di/RepositoryModule.kt
+++ b/app/src/main/java/com/example/kwh/di/RepositoryModule.kt
@@ -1,5 +1,6 @@
 package com.example.kwh.di
 
+import com.example.kwh.billing.BillingCycleCalculator
 import com.example.kwh.data.MeterDao
 import com.example.kwh.repository.MeterRepository
 import dagger.Module
@@ -7,6 +8,7 @@ import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import javax.inject.Singleton
+import java.time.Clock
 
 @Module
 @InstallIn(SingletonComponent::class)
@@ -14,7 +16,11 @@ object RepositoryModule {
 
     @Provides
     @Singleton
-    fun provideMeterRepository(meterDao: MeterDao): MeterRepository {
-        return MeterRepository(meterDao)
+    fun provideMeterRepository(
+        meterDao: MeterDao,
+        billingCycleCalculator: BillingCycleCalculator,
+        clock: Clock
+    ): MeterRepository {
+        return MeterRepository(meterDao, billingCycleCalculator, clock)
     }
 }

--- a/app/src/main/java/com/example/kwh/reminders/MeterReminderWorker.kt
+++ b/app/src/main/java/com/example/kwh/reminders/MeterReminderWorker.kt
@@ -15,7 +15,18 @@ import androidx.work.ExistingWorkPolicy
 import androidx.work.OneTimeWorkRequestBuilder
 import androidx.work.WorkManager
 import androidx.work.WorkerParameters
+import com.example.kwh.billing.CycleStats
+import com.example.kwh.repository.MeterRepository
 import com.example.kwh.settings.SettingsRepository
+import dagger.hilt.EntryPoint
+import dagger.hilt.InstallIn
+import dagger.hilt.android.EntryPointAccessors
+import dagger.hilt.components.SingletonComponent
+import java.time.LocalDate
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+import java.time.format.FormatStyle
+import java.time.temporal.ChronoUnit
 import java.time.Duration
 import java.util.concurrent.TimeUnit
 
@@ -23,6 +34,14 @@ class MeterReminderWorker(
     appContext: Context,
     workerParams: WorkerParameters
 ) : CoroutineWorker(appContext, workerParams) {
+
+    private val repository: MeterRepository by lazy {
+        val entryPoint = EntryPointAccessors.fromApplication(
+            applicationContext,
+            WorkerEntryPoint::class.java
+        )
+        entryPoint.meterRepository()
+    }
 
     override suspend fun doWork(): Result {
         val meterId = inputData.getLong(KEY_METER_ID, -1)
@@ -37,8 +56,18 @@ class MeterReminderWorker(
         val minute = inputData.getInt(KEY_MINUTE, 0)
         val snoozeMinutes = inputData.getInt(KEY_SNOOZE_MINUTES, SettingsRepository.DEFAULT_SNOOZE)
 
+        val cycleStats = repository.getCycleStats(meterId)
         Log.i(TAG, "Posting reminder for meter=$meterId name=$meterName")
-        showNotification(meterId, meterName, frequencyDays, hour, minute, snoozeMinutes)
+        val additionalLines = cycleStats?.let { buildAdditionalMessages(it) } ?: emptyList()
+        showNotification(
+            meterId = meterId,
+            meterName = meterName,
+            frequencyDays = frequencyDays,
+            hour = hour,
+            minute = minute,
+            snoozeMinutes = snoozeMinutes,
+            additionalLines = additionalLines
+        )
 
         scheduleNextReminder(
             context = applicationContext,
@@ -61,7 +90,8 @@ class MeterReminderWorker(
         frequencyDays: Int,
         hour: Int,
         minute: Int,
-        snoozeMinutes: Int
+        snoozeMinutes: Int,
+        additionalLines: List<String>
     ) {
         ensureChannel()
         val snoozeIntent = Intent(applicationContext, SnoozeReceiver::class.java).apply {
@@ -79,6 +109,10 @@ class MeterReminderWorker(
             snoozeIntent,
             pendingFlags
         )
+        val contentLines = buildList {
+            add(meterName)
+            addAll(additionalLines)
+        }
         val notification = NotificationCompat.Builder(applicationContext, CHANNEL_ID)
             .setSmallIcon(android.R.drawable.stat_notify_more)
             .setContentTitle(applicationContext.getString(com.example.kwh.R.string.reminder_notification_title))
@@ -93,9 +127,42 @@ class MeterReminderWorker(
                 ),
                 snoozePendingIntent
             )
+            .setStyle(NotificationCompat.BigTextStyle().bigText(contentLines.joinToString("\n")))
             .build()
 
         NotificationManagerCompat.from(applicationContext).notify(meterId.toInt(), notification)
+    }
+
+    private fun buildAdditionalMessages(stats: CycleStats): List<String> {
+        val zone: ZoneId = ZoneId.systemDefault()
+        val today = LocalDate.now(zone)
+        val messages = mutableListOf<String>()
+
+        val thresholdDate = stats.nextThresholdDate
+        val thresholdValue = stats.nextThreshold
+        if (thresholdDate != null && thresholdValue != null) {
+            val daysUntil = ChronoUnit.DAYS.between(today, thresholdDate)
+            if (daysUntil in 0..7) {
+                val formattedDate = thresholdDate.format(DateTimeFormatter.ofLocalizedDate(FormatStyle.MEDIUM))
+                messages += applicationContext.getString(
+                    com.example.kwh.R.string.reminder_notification_threshold,
+                    thresholdValue,
+                    formattedDate
+                )
+            }
+        }
+
+        if (stats.latest == null) {
+            val cycleStart = stats.window.start.atZone(zone).toLocalDate()
+            val daysIntoCycle = ChronoUnit.DAYS.between(cycleStart, today)
+            if (daysIntoCycle > 10) {
+                messages += applicationContext.getString(
+                    com.example.kwh.R.string.reminder_notification_no_reading
+                )
+            }
+        }
+
+        return messages
     }
 
     private fun ensureChannel() {
@@ -125,6 +192,12 @@ class MeterReminderWorker(
         const val EXTRA_HOUR = "extra_hour"
         const val EXTRA_MINUTE = "extra_minute"
         const val EXTRA_SNOOZE_MINUTES = "extra_snooze_minutes"
+
+        @EntryPoint
+        @InstallIn(SingletonComponent::class)
+        interface WorkerEntryPoint {
+            fun meterRepository(): MeterRepository
+        }
 
         fun scheduleReminder(
             context: Context,

--- a/app/src/main/java/com/example/kwh/repository/MeterRepository.kt
+++ b/app/src/main/java/com/example/kwh/repository/MeterRepository.kt
@@ -1,16 +1,30 @@
 package com.example.kwh.repository
 
+import com.example.kwh.billing.BillingCycleCalculator
+import com.example.kwh.billing.CycleStats
 import com.example.kwh.data.MeterDao
 import com.example.kwh.data.MeterEntity
 import com.example.kwh.data.MeterReadingEntity
 import com.example.kwh.data.MeterWithLatestReading
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
+import java.time.Clock
+import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneId
+import java.time.temporal.ChronoUnit
 import javax.inject.Inject
 import javax.inject.Singleton
+import kotlin.math.ceil
+import kotlin.math.max
+import kotlin.math.round
 
 @Singleton
-class MeterRepository @Inject constructor(private val meterDao: MeterDao) {
+class MeterRepository @Inject constructor(
+    private val meterDao: MeterDao,
+    private val billingCycleCalculator: BillingCycleCalculator,
+    private val clock: Clock
+) {
     val metersWithLatestReading: Flow<List<MeterWithLatestReading>> =
         meterDao.observeMetersWithReadings().map { meters ->
             meters.map { meterWithReadings ->
@@ -88,5 +102,71 @@ class MeterRepository @Inject constructor(private val meterDao: MeterDao) {
 
     suspend fun restoreReadings(readings: List<MeterReadingEntity>) {
         meterDao.insertReadings(readings)
+    }
+
+    suspend fun getCycleStats(meterId: Long): CycleStats? {
+        val meter = meterDao.getMeterById(meterId) ?: return null
+        val window = billingCycleCalculator.currentWindow(meter.billingAnchorDay, clock)
+        val zone: ZoneId = clock.zone
+        val startMillis = window.start.toEpochMilli()
+        val endMillis = window.end.toEpochMilli()
+        val earliestInWindow = meterDao.getEarliestReadingInWindow(meterId, startMillis, endMillis)
+        val baseline = earliestInWindow ?: meterDao.getLatestReadingBefore(meterId, startMillis)
+        val latest = meterDao.getLatestReadingInWindow(meterId, startMillis, endMillis)
+
+        val usedUnits = if (baseline != null && latest != null) {
+            latest.value - baseline.value
+        } else {
+            0.0
+        }
+
+        val today: LocalDate = Instant.now(clock).atZone(zone).toLocalDate()
+        val cycleStart: LocalDate = window.start.atZone(zone).toLocalDate()
+        val cycleEnd: LocalDate = window.end.atZone(zone).toLocalDate()
+        val rawDaysElapsed = ChronoUnit.DAYS.between(cycleStart, today)
+        val daysElapsed = max(1L, rawDaysElapsed.coerceAtLeast(0))
+        val cycleLengthDays = ChronoUnit.DAYS.between(cycleStart, cycleEnd).coerceAtLeast(1)
+        val rate = if (baseline != null && latest != null) usedUnits / daysElapsed else 0.0
+
+        val projectedUnits = if (baseline != null && latest != null) {
+            round(rate * cycleLengthDays)
+        } else {
+            null
+        }
+
+        val thresholds = meter.thresholdsCsv
+            .split(',')
+            .mapNotNull { value ->
+                value.trim().takeIf { it.isNotEmpty() }?.toIntOrNull()
+            }
+            .sorted()
+
+        val nextThresholdInfo = if (baseline != null && latest != null && rate > 0.0) {
+            thresholds.firstNotNullOfOrNull { threshold ->
+                if (threshold > usedUnits) {
+                    val daysUntil = ceil((threshold - usedUnits) / rate).toLong()
+                    val eta = today.plusDays(daysUntil)
+                    if (eta.isBefore(cycleEnd)) {
+                        threshold to eta
+                    } else {
+                        null
+                    }
+                } else {
+                    null
+                }
+            }
+        } else {
+            null
+        }
+
+        return CycleStats(
+            window = window,
+            baseline = baseline,
+            latest = latest,
+            usedUnits = usedUnits,
+            projectedUnits = projectedUnits,
+            nextThreshold = nextThresholdInfo?.first,
+            nextThresholdDate = nextThresholdInfo?.second
+        )
     }
 }

--- a/app/src/main/java/com/example/kwh/ui/history/HistoryViewModel.kt
+++ b/app/src/main/java/com/example/kwh/ui/history/HistoryViewModel.kt
@@ -47,11 +47,16 @@ class HistoryViewModel @Inject constructor(
     // Cache the most recently deleted reading for undo support
     private var recentlyDeleted: MeterReadingEntity? = null
 
+    private var billingAnchorDay: Int = 1
+    private var thresholdsCsv: String = "200,300"
+
     init {
         // Load the meter name and readings
         viewModelScope.launch {
             // Fetch meter to get its name
             repository.getMeter(meterId)?.let { meter ->
+                billingAnchorDay = meter.billingAnchorDay
+                thresholdsCsv = meter.thresholdsCsv
                 _uiState.value = _uiState.value.copy(meterName = meter.name)
             }
             // Collect readings for this meter. When they change the UI state is updated.
@@ -157,6 +162,8 @@ class HistoryViewModel @Inject constructor(
                 val newReadings = mutableListOf<MeterReadingEntity>()
                 val reader = BufferedReader(StringReader(csv))
                 reader.readLine() // skip header if present
+                var importedAnchor = 1
+                var importedThresholds = "200,300"
                 while (true) {
                     val line = reader.readLine() ?: break
                     val parts = line.split(',')
@@ -164,6 +171,17 @@ class HistoryViewModel @Inject constructor(
                     val timestamp = parts[0].toLongOrNull()
                     val value = parts[1].toDoubleOrNull()
                     val notes = parts.getOrNull(2)?.takeIf { it.isNotBlank() }
+                    parts.getOrNull(3)?.toIntOrNull()?.let { anchor ->
+                        if (anchor in 1..31) {
+                            importedAnchor = anchor
+                        }
+                    }
+                    parts.getOrNull(4)?.let { thresholds ->
+                        val trimmed = thresholds.trim()
+                        if (trimmed.isNotEmpty()) {
+                            importedThresholds = trimmed
+                        }
+                    }
                     if (timestamp != null && value != null && value > 0.0) {
                         newReadings += MeterReadingEntity(
                             id = 0L,
@@ -179,6 +197,15 @@ class HistoryViewModel @Inject constructor(
                     return@launch
                 }
                 repository.restoreReadings(newReadings)
+                repository.getMeter(meterId)?.let { meter ->
+                    val updated = meter.copy(
+                        billingAnchorDay = importedAnchor,
+                        thresholdsCsv = importedThresholds
+                    )
+                    repository.updateMeter(updated)
+                    billingAnchorDay = updated.billingAnchorDay
+                    thresholdsCsv = updated.thresholdsCsv
+                }
                 _events.send(HistoryEvent.Imported(newReadings.size))
             } catch (e: Exception) {
                 _events.send(HistoryEvent.Error("Failed to import CSV"))
@@ -210,13 +237,17 @@ class HistoryViewModel @Inject constructor(
      */
     private fun buildCsv(readings: List<HistoryReading>): String {
         val builder = StringBuilder()
-        builder.append("timestamp,value,notes\n")
+        builder.append("timestamp,value,notes,billing_anchor_day,thresholds\n")
         readings.forEach { reading ->
             builder.append(reading.recordedAt.toEpochMilli())
                 .append(',')
                 .append(reading.value)
                 .append(',')
                 .append(reading.notes ?: "")
+                .append(',')
+                .append(billingAnchorDay)
+                .append(',')
+                .append(thresholdsCsv)
                 .append('\n')
         }
         return builder.toString()

--- a/app/src/main/java/com/example/kwh/ui/history/HistoryViewModel.kt
+++ b/app/src/main/java/com/example/kwh/ui/history/HistoryViewModel.kt
@@ -277,6 +277,7 @@ class HistoryViewModel @Inject constructor(
      */
     private fun buildCsv(readings: List<HistoryReading>): String {
         val builder = StringBuilder()
+        builder.append("# version: 1\n")
         builder.append("timestamp,value,notes,billing_anchor_day,thresholds\n")
         readings.forEach { reading ->
             builder.append(reading.recordedAt.toEpochMilli())

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -52,6 +52,8 @@
     <!-- Reminder notification strings -->
     <string name="reminder_notification_title">Time to log your meter reading</string>
     <string name="snooze_for_minutes">Snooze for %1$d minutes</string>
+    <string name="reminder_notification_threshold">Projected to cross %1$d units on %2$s.</string>
+    <string name="reminder_notification_no_reading">No reading logged yet this cycle. Add a reading to stay on track.</string>
 
     <!-- Settings -->
     <string name="settings_title">Settings</string>

--- a/app/src/test/java/com/example/kwh/billing/DefaultBillingCycleCalculatorTest.kt
+++ b/app/src/test/java/com/example/kwh/billing/DefaultBillingCycleCalculatorTest.kt
@@ -34,6 +34,36 @@ class DefaultBillingCycleCalculatorTest {
     }
 
     @Test
+    fun `anchor 29 handles february in non leap year`() {
+        val clock = Clock.fixed(Instant.parse("2023-02-20T00:00:00Z"), zone)
+
+        val window = calculator.currentWindow(anchorDay = 29, clock = clock)
+
+        assertEquals("2023-01-29", window.start.atZone(zone).toLocalDate().toString())
+        assertEquals("2023-02-28", window.end.atZone(zone).toLocalDate().toString())
+    }
+
+    @Test
+    fun `anchor 30 handles february in non leap year`() {
+        val clock = Clock.fixed(Instant.parse("2023-02-20T00:00:00Z"), zone)
+
+        val window = calculator.currentWindow(anchorDay = 30, clock = clock)
+
+        assertEquals("2023-01-30", window.start.atZone(zone).toLocalDate().toString())
+        assertEquals("2023-02-28", window.end.atZone(zone).toLocalDate().toString())
+    }
+
+    @Test
+    fun `anchor 31 handles february in non leap year`() {
+        val clock = Clock.fixed(Instant.parse("2023-02-20T00:00:00Z"), zone)
+
+        val window = calculator.currentWindow(anchorDay = 31, clock = clock)
+
+        assertEquals("2023-01-31", window.start.atZone(zone).toLocalDate().toString())
+        assertEquals("2023-02-28", window.end.atZone(zone).toLocalDate().toString())
+    }
+
+    @Test
     fun `leap year preserves february 29 for anchor 31`() {
         val clock = Clock.fixed(Instant.parse("2024-02-20T00:00:00Z"), zone)
 

--- a/app/src/test/java/com/example/kwh/repository/MeterRepositoryCycleStatsTest.kt
+++ b/app/src/test/java/com/example/kwh/repository/MeterRepositoryCycleStatsTest.kt
@@ -1,0 +1,132 @@
+package com.example.kwh.repository
+
+import com.example.kwh.billing.DefaultBillingCycleCalculator
+import com.example.kwh.data.MeterEntity
+import com.example.kwh.data.MeterReadingEntity
+import com.example.kwh.testing.FakeMeterDao
+import java.time.Clock
+import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneOffset
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class MeterRepositoryCycleStatsTest {
+
+    private val zone = ZoneOffset.UTC
+    private val clock: Clock = Clock.fixed(Instant.parse("2024-03-25T00:00:00Z"), zone)
+    private lateinit var dao: FakeMeterDao
+    private lateinit var repository: MeterRepository
+
+    @Before
+    fun setUp() {
+        dao = FakeMeterDao()
+        repository = MeterRepository(dao, DefaultBillingCycleCalculator(), clock)
+    }
+
+    @Test
+    fun `baseline uses earliest reading within window`() = runTest {
+        val meterId = dao.insertMeter(
+            MeterEntity(name = "Home", billingAnchorDay = 15, thresholdsCsv = "50,80")
+        )
+        dao.insertReading(reading(meterId, "2024-03-10", 100.0))
+        val baselineId = dao.insertReading(reading(meterId, "2024-03-16", 110.0))
+        val latestId = dao.insertReading(reading(meterId, "2024-03-24", 130.0))
+
+        val stats = repository.getCycleStats(meterId)
+
+        assertNotNull(stats)
+        assertEquals(baselineId, stats.baseline?.id)
+        assertEquals(latestId, stats.latest?.id)
+        assertEquals(20.0, stats.usedUnits, 1e-6)
+    }
+
+    @Test
+    fun `baseline falls back to reading before window`() = runTest {
+        val meterId = dao.insertMeter(
+            MeterEntity(name = "Office", billingAnchorDay = 15)
+        )
+        dao.insertReading(reading(meterId, "2024-03-10", 200.0))
+        dao.insertReading(reading(meterId, "2024-03-05", 180.0))
+
+        val stats = repository.getCycleStats(meterId)
+
+        assertNotNull(stats)
+        assertEquals(200.0, stats.baseline?.value)
+        assertNull(stats.latest)
+        assertEquals(0.0, stats.usedUnits, 1e-6)
+    }
+
+    @Test
+    fun `projection handles zero rate`() = runTest {
+        val meterId = dao.insertMeter(
+            MeterEntity(name = "Lab", billingAnchorDay = 15)
+        )
+        dao.insertReading(reading(meterId, "2024-03-15", 100.0))
+        dao.insertReading(reading(meterId, "2024-03-22", 100.0))
+
+        val stats = repository.getCycleStats(meterId)
+
+        assertNotNull(stats)
+        assertEquals(0.0, stats.projectedUnits)
+    }
+
+    @Test
+    fun `projection rounds to nearest whole unit`() = runTest {
+        val meterId = dao.insertMeter(
+            MeterEntity(name = "Cabin", billingAnchorDay = 15)
+        )
+        dao.insertReading(reading(meterId, "2024-03-15", 100.0))
+        dao.insertReading(reading(meterId, "2024-03-22", 105.0))
+
+        val stats = repository.getCycleStats(meterId)
+
+        assertNotNull(stats)
+        assertEquals(16.0, stats.projectedUnits)
+    }
+
+    @Test
+    fun `threshold eta only returns values within cycle`() = runTest {
+        val meterId = dao.insertMeter(
+            MeterEntity(name = "Garden", billingAnchorDay = 15, thresholdsCsv = "50,80")
+        )
+        dao.insertReading(reading(meterId, "2024-03-15", 100.0))
+        dao.insertReading(reading(meterId, "2024-03-25", 140.0))
+
+        val stats = repository.getCycleStats(meterId)
+
+        assertNotNull(stats)
+        assertEquals(50, stats.nextThreshold)
+        assertEquals(LocalDate.parse("2024-03-28"), stats.nextThresholdDate)
+    }
+
+    @Test
+    fun `threshold eta omitted when beyond cycle end`() = runTest {
+        val meterId = dao.insertMeter(
+            MeterEntity(name = "Basement", billingAnchorDay = 15, thresholdsCsv = "200")
+        )
+        dao.insertReading(reading(meterId, "2024-03-15", 100.0))
+        dao.insertReading(reading(meterId, "2024-03-25", 140.0))
+
+        val stats = repository.getCycleStats(meterId)
+
+        assertNotNull(stats)
+        assertNull(stats.nextThreshold)
+        assertNull(stats.nextThresholdDate)
+    }
+
+    private fun reading(meterId: Long, date: String, value: Double): MeterReadingEntity {
+        return MeterReadingEntity(
+            meterId = meterId,
+            value = value,
+            notes = null,
+            recordedAt = LocalDate.parse(date).atStartOfDay(zone).toInstant().toEpochMilli()
+        )
+    }
+}

--- a/app/src/test/java/com/example/kwh/testing/FakeMeterDao.kt
+++ b/app/src/test/java/com/example/kwh/testing/FakeMeterDao.kt
@@ -34,6 +34,32 @@ class FakeMeterDao : MeterDao {
         return readings.find { it.id == readingId }
     }
 
+    override suspend fun getLatestReadingBefore(meterId: Long, start: Long): MeterReadingEntity? {
+        return readings
+            .filter { it.meterId == meterId && it.recordedAt < start }
+            .maxByOrNull { it.recordedAt }
+    }
+
+    override suspend fun getEarliestReadingInWindow(
+        meterId: Long,
+        start: Long,
+        end: Long
+    ): MeterReadingEntity? {
+        return readings
+            .filter { it.meterId == meterId && it.recordedAt in start until end }
+            .minByOrNull { it.recordedAt }
+    }
+
+    override suspend fun getLatestReadingInWindow(
+        meterId: Long,
+        start: Long,
+        end: Long
+    ): MeterReadingEntity? {
+        return readings
+            .filter { it.meterId == meterId && it.recordedAt in start until end }
+            .maxByOrNull { it.recordedAt }
+    }
+
     override suspend fun insertMeter(meter: MeterEntity): Long {
         val assignedId = if (meter.id == 0L) nextMeterId++ else meter.id
         val entity = meter.copy(id = assignedId)

--- a/app/src/test/java/com/example/kwh/ui/home/HomeViewModelTest.kt
+++ b/app/src/test/java/com/example/kwh/ui/home/HomeViewModelTest.kt
@@ -1,6 +1,7 @@
 package com.example.kwh.ui.home
 
 import android.app.Application
+import com.example.kwh.billing.DefaultBillingCycleCalculator
 import com.example.kwh.data.MeterEntity
 import com.example.kwh.repository.MeterRepository
 import com.example.kwh.reminders.ReminderScheduler
@@ -17,6 +18,9 @@ import kotlinx.coroutines.test.runTest
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneOffset
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class HomeViewModelTest {
@@ -27,11 +31,12 @@ class HomeViewModelTest {
     private lateinit var repository: MeterRepository
     private lateinit var scheduler: RecordingScheduler
     private lateinit var viewModel: HomeViewModel
+    private val clock: Clock = Clock.fixed(Instant.parse("2024-03-20T00:00:00Z"), ZoneOffset.UTC)
 
     @Before
     fun setup() {
         val dao = FakeMeterDao()
-        repository = MeterRepository(dao)
+        repository = MeterRepository(dao, DefaultBillingCycleCalculator(), clock)
         scheduler = RecordingScheduler(Application(), FakeSnoozePreferenceReader())
         viewModel = HomeViewModel(
             repository = repository,


### PR DESCRIPTION
## Summary
- provide billing cycle calculations and clock bindings through a new Hilt module
- compute per-meter cycle stats in the repository for projections and threshold ETAs
- surface cycle stats in reminder notifications and enrich history CSV import/export with meter metadata
- extend unit coverage for billing windows, cycle stats, and threshold prediction logic

## Testing
- `./gradlew test` *(fails: Android SDK not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e0cc86463c8323a060a7da76c8a497