### PR TITLE
Fix threshold forecast usage in reminder worker

### DIFF
--- a/app/src/main/java/com/example/kwh/reminders/MeterReminderWorker.kt
+++ b/app/src/main/java/com/example/kwh/reminders/MeterReminderWorker.kt
@@ -140,13 +140,12 @@ class MeterReminderWorker(
         val thresholdForecast = stats.nextThreshold
         if (thresholdForecast != null) {
             val thresholdDate = thresholdForecast.eta
-            val thresholdValue = thresholdForecast.threshold
             val daysUntil = ChronoUnit.DAYS.between(today, thresholdDate)
             if (daysUntil in 0 until THRESHOLD_WARNING_WINDOW_DAYS) {
-                val formattedDate = forecast.eta.format(DateTimeFormatter.ofLocalizedDate(FormatStyle.MEDIUM))
+                val formattedDate = thresholdDate.format(DateTimeFormatter.ofLocalizedDate(FormatStyle.MEDIUM))
                 messages += applicationContext.getString(
                     com.example.kwh.R.string.reminder_notification_threshold,
-                    forecast.threshold,
+                    thresholdForecast.threshold,
                     formattedDate
                 )
             }


### PR DESCRIPTION
## Summary
- update MeterReminderWorker to reuse the existing threshold forecast details when building reminder messages
- remove stray references to an undefined forecast object so the threshold notification message is built correctly

## Testing
- `./gradlew :app:compileDebugKotlin` *(fails: SDK location not found in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e259e6ca70832387d7969b96064a55