### PR TITLE
Add deployment readiness review summary

### DIFF
--- a/docs/deployment-readiness-review.md
+++ b/docs/deployment-readiness-review.md
@@ -1,0 +1,8 @@
+# Deployment Readiness Review
+
+## Summary
+- `MeterReminderWorker` now references `thresholdForecast` when composing threshold warnings, resolving the undefined identifier that previously prevented compilation.
+- `HistoryViewModel` refreshes `billingAnchorDay` and `thresholdsCsv` from the active meter overview and after CSV imports, so exports reflect the latest configuration.
+
+## Outstanding Concerns
+- Android SDK is not provisioned in this environment, so the Gradle build fails locally. Ensure CI or release builds run with a configured SDK.


### PR DESCRIPTION
## Summary
- add a deployment readiness review document that captures the latest audit findings

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68e2511a62b88323830424c14286fa8b