### PR TITLE
Add date selection when logging meter readings

### DIFF
--- a/app/src/main/java/com/example/kwh/MainActivity.kt
+++ b/app/src/main/java/com/example/kwh/MainActivity.kt
@@ -97,8 +97,8 @@ class MainActivity : ComponentActivity() {
                             onAddReadingClick = { meterId ->
                                 homeViewModel.showAddReadingDialog(meterId, true)
                             },
-                            onAddReading = { id, value, notes ->
-                                homeViewModel.addReading(id, value, notes)
+                            onAddReading = { id, value, notes, recordedAt ->
+                                homeViewModel.addReading(id, value, notes, recordedAt)
                             },
                             onDismissReading = {
                                 homeViewModel.showAddReadingDialog(null, false)

--- a/app/src/main/java/com/example/kwh/ui/home/HomeScreen.kt
+++ b/app/src/main/java/com/example/kwh/ui/home/HomeScreen.kt
@@ -590,7 +590,7 @@ private fun AddReadingDialog(
     var readingText by remember { mutableStateOf("") }
     var notes by remember { mutableStateOf("") }
     var showError by remember { mutableStateOf(false) }
-    var selectedDate by remember(meterId) { mutableStateOf(LocalDate.now()) }
+    var selectedDate by remember { mutableStateOf(LocalDate.now()) }
     val zoneId = remember { ZoneId.systemDefault() }
     val context = LocalContext.current
     val dateFormatter = remember {

--- a/app/src/main/java/com/example/kwh/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/com/example/kwh/ui/home/HomeViewModel.kt
@@ -70,18 +70,19 @@ class HomeViewModel @Inject constructor(
         }
     }
 
-    fun addReading(meterId: Long, value: Double, notes: String?) {
+    fun addReading(meterId: Long, value: Double, notes: String?, recordedAt: Long) {
         if (value.isNaN() || value <= 0.0) {
             emitError(stringResolver.get(R.string.error_positive_reading))
             return
         }
+        val sanitizedRecordedAt = minOf(recordedAt, System.currentTimeMillis())
         viewModelScope.launch {
             runCatching {
                 repository.addReading(
                     meterId = meterId,
                     value = value,
                     notes = notes,
-                    recordedAt = System.currentTimeMillis()
+                    recordedAt = sanitizedRecordedAt
                 )
             }.onSuccess {
             }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -16,6 +16,7 @@
     <!-- Home screen strings -->
     <string name="reading_value">Reading value</string>
     <string name="reading_notes">Notes</string>
+    <string name="reading_recorded_on">Recorded on %1$s</string>
     <string name="reminder_frequency_days">Reminder frequency (days)</string>
     <string name="reminder_time_hour">Hour</string>
     <string name="reminder_time_minute">Minute</string>


### PR DESCRIPTION
## Summary
- add a date picker control to the add reading dialog so users can choose when the reading was recorded
- plumb the selected timestamp through the home screen, activity, and view model to store readings on the chosen day
- cap recorded timestamps at the current time and add supporting strings

## Testing
- ./gradlew testDebugUnitTest *(fails: missing Android SDK in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e2763999d08323a462d43f771d2b25